### PR TITLE
Specify SimpleDateFormat's timezone as UTC

### DIFF
--- a/TransloaditLib/src/hu/szabot/transloadit/assembly/AssemblyBuilder.java
+++ b/TransloaditLib/src/hu/szabot/transloadit/assembly/AssemblyBuilder.java
@@ -17,6 +17,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.TimeZone;
 
 import android.annotation.SuppressLint;
 
@@ -115,6 +116,7 @@ public class AssemblyBuilder implements IAssemblyBuilder
 	public void setAuthExpires(Date dateTime)
     {
     	DateFormat df = new SimpleDateFormat("yyyy/MM/dd HH:mm:ss+00:00");
+    	df.setTimeZone(TimeZone.getTimeZone("UTC"));
         auth.put("expires",df.format(dateTime));
     }
     


### PR DESCRIPTION
Make it so that assemblies created at <= UTC-2 aren't already expired.