### PR TITLE
ci: fetch Git LFS assets in CI

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -32,6 +32,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          lfs: true
       - name: Set up JDK ${{ matrix.java }}
         uses: actions/setup-java@v4
         with:


### PR DESCRIPTION
## Summary
Enable Git LFS checkout in CI.

## Why
The last failing run happened right after moving test assets to LFS. Without LFS checkout, CI can run against pointer files instead of the real binary fixtures (for example `chameleon.jpg`), which can break both Gradle and Docker harness test flows.

## Changes
- Set `lfs: true` on `actions/checkout@v4` in the Android CI job.

## Notes
The historical failed run logs are expired (HTTP 410 from GitHub Actions logs endpoint), so this change is based on workflow/repo inspection and failure timing.
